### PR TITLE
update foundation js location for foundation 6.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,6 +16,6 @@
     "tests"
   ],
   "dependencies": {
-    "foundation-sites": "^6.2.3"
+    "foundation-sites": "~6.3.0"
   }
 }

--- a/gulpconfig.js
+++ b/gulpconfig.js
@@ -36,7 +36,7 @@
       {
         src: [
           './bower_components/what-input/what-input.js',
-          './bower_components/foundation-sites/dist/foundation.js'
+          './bower_components/foundation-sites/dist/js/foundation.js'
         ],
         concat: 'libs.js',
         min: true,


### PR DESCRIPTION
Foundation reorganized assets in the `dist` directory in 6.3, so the path to `foundation.js` needs to be updated in the gulp config

old dist: [6.2](https://github.com/zurb/foundation-sites/tree/v6.2.4/dist)
new dist: [6.3](https://github.com/zurb/foundation-sites/tree/v6.3.0/dist)