### PR TITLE
Bump MySQL max allowed packet to 16mb

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@ Development
 -----------
 * rm -rf composer dependencies before attempting final optimized install to fix Drupal console uninstall bug. See https://github.com/hechoendrupal/drupal-console-extend-plugin/issues/2
 * gitignore "-n" file from backstop container.
+* Bump MySQL max allowed packet to 16mb.
 
 1.2.0 2017-03-23
 ----------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     image: "mysql:5.6"
     volumes:
       - mysql_data:/var/lib/mysql
+      - ./docker/mysql-extra.cnf:/etc/mysql/conf.d/extra.cnf
     environment:
       - MYSQL_ROOT_PASSWORD=root
       - MYSQL_USER=drupal


### PR DESCRIPTION
Raises the MySQL max allowed packet to 16mb for the Docker MySQL container.  This fixes errrors with some sites that write very large rows into the cache tables.