### PR TITLE
Add config file to set max_allowed_packet to 16M for mysql container

### DIFF
--- a/docker/mysql-extra.cnf
+++ b/docker/mysql-extra.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_allowed_packet=16M


### PR DESCRIPTION
Looks like the mysql config file for bumping max_allowed_packet in mysql didn't make it into the commit in https://github.com/LastCallMedia/Drupal-Scaffold/commit/bf8d3279e303fab3d3718d7728e4a347269317f9. This adds it in