### PR TITLE
add js files used to trigger attachBehaviors on document within mannequin

### DIFF
--- a/.mannequin.php
+++ b/.mannequin.php
@@ -24,7 +24,9 @@ $config = MannequinConfig::create()
   ])
   ->setGlobalJs([
     'web/core/assets/vendor/jquery/jquery.min.js',
+    'web/core/assets/vendor/domready/ready.min.js',
     'web/core/misc/drupal.js',
+    'web/core/misc/drupal.init.js',
     'web/themes/custom/scaffold/dist/js/libs.min.js',
     'web/themes/custom/scaffold/dist/js/theme.min.js',
   ]);


### PR DESCRIPTION
This adds the files that are used for attaching behaviors to the global JS for Mannequin. Once the component has finished loading within the iframe, `Drupal.attachBehaviors()` will be called for the document, allowing js code that is triggered by `attachBehaviors()` to run the same within Mannequin as it does within Drupal.