### PR TITLE
Add COMPOSER_AUTH variable to pass composer tokens into Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,14 @@
 # BLACKFIRE_SERVER_ID=
 # BLACKFIRE_SERVER_TOKEN=
 
+# Inject Composer authentication information into your Docker containers.
+#
+# This is a JSON string.  Hint: Rather than setting this here, you can also
+# add the following line to your .bash_profile to have it set automatically
+# for every project:
+#   export COMPOSER_AUTH=$(cat ~/.composer/auth.json)
+
+# COMPOSER_AUTH
 
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       BLACKFIRE_CLIENT_ID: # Optionally set in .env.
       BLACKFIRE_CLIENT_TOKEN: # Optionally set in .env.
       COMPOSER_ALLOW_SUPERUSER: 1
+      COMPOSER_AUTH: # Optionally pulled from environment
     working_dir: /var/www
 
   mysql:


### PR DESCRIPTION
This PR allows us to pull our composer authentication tokens from outside the container to the inside.  It can be enabled by adding the following line to `.bash_profile`: 

```
export COMPOSER_AUTH=$(cat ~/.composer/auth.json)
```