### PR TITLE
Update env example to tell users to config xdebug with correct host.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,11 @@
 # Inject XDebug configuration into your docker containers:
 #
 # Configures XDebug for debugging.
+#
+# NOTE: Docker started using host.docker.internal with version 18.03. If you're using an older version
+# upgrade or use docker.for.mac.localhost.
 
-# XDEBUG_CONFIG=remote_host=docker.for.mac.localhost
+# XDEBUG_CONFIG=remote_host=host.docker.internal
 
 # Inject Blackfire credentials into your docker containers.
 #


### PR DESCRIPTION
Docker since 18.03 recommends using a different hostname for connecting to the host machine. The old hostname still works for now.

Also, as a note to others or perhaps to start a discussion, in my container I'm replacing xdebug.ini with the following and I have it working with vscode. 
```
xdebug.remote_enable=1
xdebug.remote_autostart=1
```