### PR TITLE
Fix typo in link XDebug link example.

### DIFF
--- a/docs/tools/xdebug.md
+++ b/docs/tools/xdebug.md
@@ -18,7 +18,7 @@ Usage
 
 1. Using PHPStorm, add a new "PHP Remote Debug" configuration.
 2. Set breakpoints in your code.
-3. Visit the site in your browser, adding the XDEBUG_SESSION_START query parameter to the end of the URL.  Example: http://localhost:8080:?XDEBUG_SESSION_START
+3. Visit the site in your browser, adding the XDEBUG_SESSION_START query parameter to the end of the URL.  Example: http://localhost:8080?XDEBUG_SESSION_START
 4. Step through code in your IDE.
 
 Uninstalling


### PR DESCRIPTION
Fixed:
- Removed colon from XDebug session start link example.