### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @lynnschumann @jlandfried


### PR DESCRIPTION
This PR adds a [CODEOWNERS](https://help.github.com/articles/about-code-owners/) file to designate our new maintainers.  Whohoo!