### PR TITLE
Update lastcall-artifact.sh to 1.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
       - run: {name: 'Trust host key', command: 'ssh-keyscan -p $GIT_PORT $GIT_HOST >> /etc/ssh/ssh_known_hosts'}
       - run: {name: 'Set git committer', command: 'git config --global user.email "$GIT_AUTHOR_EMAIL" && git config --global user.name "$GIT_AUTHOR_NAME"'}
       - run: {name: 'Lean Composer install', command: 'composer install --no-dev -o -n'}
-      - run: {name: 'Push Artifact', command: 'node_modules/.bin/artifact.sh -a $GIT_URL -b $CIRCLE_BRANCH'}
+      - run: {name: 'Push Artifact', command: 'node_modules/.bin/artifactsh -a $GIT_URL -b $CIRCLE_BRANCH'}
       - run: {name: 'Ensure multidev', command: 'test $CIRCLE_BRANCH == "master" || bin/create-artifact-environment-pantheon -b $CIRCLE_BRANCH -s $TERMINUS_SOURCE_ENVIRONMENT'}
       - run: {name: 'Prune multidev environments', command: 'bin/prune-artifact-environments-pantheon -p "p-*"'}
       - run: {name: 'Prune branches', command: 'bin/prune-artifact-branches -a $GIT_URL -p "p-*"'}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update to PHP 7.2.
 * Update to Gulp 4 via lastcall-gulp-drupal-tasks. Gulpfiles will need to be updated with the contents of [gulpfile.js](./gulpfile.js).
 * Update to Circle 2.1 configuration. This configuration syntax allows the usage of "orbs" in the build.
+* Update to lastcall-artifact.sh to 1.0.0. Change binary name that gets called in CircleCI deploy script.
 
 ### Added
 * Added base node, block, field, and view templates that include unique classes to help with theming.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "eslint": "^4.12.1",
     "foundation-sites": "^6.4.3",
     "gulp": "^4.0.0",
-    "lastcall-artifact.sh": "^0.2.2",
+    "lastcall-artifact.sh": "^1.0.0",
     "lastcall-gulp-drupal-tasks": "^3.0.1",
     "what-input": "^5.2.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,9 +1828,10 @@ last-run@^1.1.0:
     default-resolution "^2.0.0"
     es6-weak-map "^2.0.1"
 
-lastcall-artifact.sh@^0.2.2:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/lastcall-artifact.sh/-/lastcall-artifact.sh-0.2.3.tgz#eb001213a4ca0bb52b0cfc284e3501c87b7fc70e"
+lastcall-artifact.sh@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lastcall-artifact.sh/-/lastcall-artifact.sh-1.0.0.tgz#f3d251178df3fe9cea58cffec88c1bbda34aac98"
+  integrity sha512-0Or7RBeO9xj/EnkZXAIA00MUq5pBbQzD6nYUs3+K0e6O7hlcvshPv0rR+WHhELWcbfz21xYDhot7itRDC6HtWw==
 
 lastcall-gulp-drupal-tasks@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Newer versions of yarn has issues when we specify binary files with a `.` in the filename. [lastcall-artifact.sh](https://github.com/LastCallMedia/Artifact.sh) has been updated to `1.0.0` to address this.

We had to pull in a newer version of `lastcall-artifact.sh` and change the filename of the binary that we call in circleci to make this work correctly again.